### PR TITLE
Add url support for visualizerFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ At the moment the extension extracts the Qt file locations from CMake only (from
   This extension try to detect the Qt Creator installation automatically (on Windows and MacOS). You can set the executable path via `qttools.creator` settings if the extension can't find Qt Creator (for whatever reason)
 * [x] Extract the Qt file locations from the cmake cache (`CMakeCache.txt`). The cmake build directory is extracted from the vscode extension [CMake Tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools) setting `cmake.buildDirectory`. 
   So you need to configure your project for the first time and afterwards every Qt tool is found automatically (when it is installed on your disk ;-) ).
-* [x] Debugger extensions (via natvis files) (partially implemented)<br>
-  The Qt natvis file from this extension will automatically get injected into your existing `launch.json` file (per default). If you don't like that feature you can turn it of via `qttools.injectNatvisFile` setting.
-  You can also set your custom created/downloaded qt natvis file instead of the bundled one via the `qttools.visualizerFile` (f.e. you can download the one from the offical [Qt Visual Studio Tools](https://code.qt.io/cgit/qt-labs/vstools.git/tree/src/qtvstools/qt5.natvis.xml))
+* [x] Debugger extensions (via natvis files)<br>
+  The Qt natvis file from this extension will automatically get injected into your existing `launch.json` file (per default). If you don't like that feature you can turn it of via `qttools.injectNatvisFile` setting.<br>
+  You can also set your custom created/downloaded qt natvis file instead of the bundled one (which implement a few Qt types) by setting `qttools.visualizerFile` to a filepath or url (f.e. you can set `qttools.visualizerFile` to the natvis file from the offical [Qt Visual Studio Tools](https://code.qt.io/cgit/qt-labs/vstools.git/tree/src/qtvstools/qt5.natvis.xml) `https://code.qt.io/cgit/qt-labs/vstools.git/plain/src/qtvstools/qt5.natvis.xml`). When you set an url, the extension will only download it ones and cache it and will use the cached local version<br>
+  NOTE: I cannot bundle the Qt Visual Studio Tools natvis file into the extension itself because of it's license restrictions (MIT vs GPL)!
 * [ ] qml language support (there are already some VSCode extensions)
 * ...
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,31 @@
 				"js-tokens": "^4.0.0"
 			}
 		},
+		"@sindresorhus/is": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
+			"integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
+		},
+		"@types/decompress": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/@types/decompress/-/decompress-4.2.3.tgz",
+			"integrity": "sha512-W24e3Ycz1UZPgr1ZEDHlK4XnvOr+CpJH3qNsFeqXwwlW/9END9gxn3oJSsp7gYdiQxrXUHwUUd3xuzVz37MrZQ==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/download": {
+			"version": "6.2.4",
+			"resolved": "https://registry.npmjs.org/@types/download/-/download-6.2.4.tgz",
+			"integrity": "sha512-Lo5dy3ai6LNnbL663sgdzqL1eib11u1yKH6w3v3IXEOO4kRfQpMn1qWUTaumcHLACjFp1RcBx9tUXEvJoR3vcA==",
+			"dev": true,
+			"requires": {
+				"@types/decompress": "*",
+				"@types/got": "^8",
+				"@types/node": "*"
+			}
+		},
 		"@types/events": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -38,6 +63,15 @@
 			"requires": {
 				"@types/events": "*",
 				"@types/minimatch": "*",
+				"@types/node": "*"
+			}
+		},
+		"@types/got": {
+			"version": "8.3.5",
+			"resolved": "https://registry.npmjs.org/@types/got/-/got-8.3.5.tgz",
+			"integrity": "sha512-AaXSrIF99SjjtPVNmCmYb388HML+PKEJb/xmj4SbL2ZO0hHuETZZzyDIKfOqaEoAHZEuX4sC+FRFrHYJoIby6A==",
+			"dev": true,
+			"requires": {
 				"@types/node": "*"
 			}
 		},
@@ -58,6 +92,25 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.24.tgz",
 			"integrity": "sha512-1Ciqv9pqwVtW6FsIUKSZNB82E5Cu1I2bBTj1xuIHXLe/1zYLl3956Nbhg2MzSYHVfl9/rmanjbQIb7LibfCnug==",
 			"dev": true
+		},
+		"@types/rimraf": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-2.0.3.tgz",
+			"integrity": "sha512-dZfyfL/u9l/oi984hEXdmAjX3JHry7TLWw43u1HQ8HhPv6KtfxnrZ3T/bleJ0GEvnk9t5sM7eePkgMqz3yBcGg==",
+			"dev": true,
+			"requires": {
+				"@types/glob": "*",
+				"@types/node": "*"
+			}
+		},
+		"@types/sha.js": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@types/sha.js/-/sha.js-2.4.0.tgz",
+			"integrity": "sha512-amxKgPy6WJTKuw8mpUwjX2BSxuBtBmZfRwIUDIuPJKNwGN8CWDli8JTg5ONTWOtcTkHIstvT7oAhhYXqEjStHQ==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
 		},
 		"@types/vscode": {
 			"version": "1.41.0",
@@ -95,6 +148,21 @@
 				"color-convert": "^1.9.0"
 			}
 		},
+		"archive-type": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/archive-type/-/archive-type-4.0.0.tgz",
+			"integrity": "sha1-+S5yIzBW38aWlHJ0nCZ72wRrHXA=",
+			"requires": {
+				"file-type": "^4.2.0"
+			},
+			"dependencies": {
+				"file-type": {
+					"version": "4.4.0",
+					"resolved": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
+					"integrity": "sha1-G2AOX8ofvcboDApwxxyNul95BsU="
+				}
+			}
+		},
 		"argparse": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -107,14 +175,26 @@
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"dev": true
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+		},
+		"base64-js": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+		},
+		"bl": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+			"integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+			"requires": {
+				"readable-stream": "^2.3.5",
+				"safe-buffer": "^5.1.1"
+			}
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -126,17 +206,82 @@
 			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
 			"dev": true
 		},
+		"buffer": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
+			"integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+			"requires": {
+				"base64-js": "^1.0.2",
+				"ieee754": "^1.1.4"
+			}
+		},
+		"buffer-alloc": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+			"integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+			"requires": {
+				"buffer-alloc-unsafe": "^1.1.0",
+				"buffer-fill": "^1.0.0"
+			}
+		},
+		"buffer-alloc-unsafe": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+			"integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+		},
+		"buffer-crc32": {
+			"version": "0.2.13",
+			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+		},
+		"buffer-fill": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+			"integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
+		},
 		"builtin-modules": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
 			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
 			"dev": true
 		},
+		"cacheable-request": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
+			"integrity": "sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=",
+			"requires": {
+				"clone-response": "1.0.2",
+				"get-stream": "3.0.0",
+				"http-cache-semantics": "3.8.1",
+				"keyv": "3.0.0",
+				"lowercase-keys": "1.0.0",
+				"normalize-url": "2.0.1",
+				"responselike": "1.0.2"
+			},
+			"dependencies": {
+				"lowercase-keys": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+					"integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+				}
+			}
+		},
 		"camelcase": {
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
 			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 			"dev": true
+		},
+		"caw": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/caw/-/caw-2.0.1.tgz",
+			"integrity": "sha512-Cg8/ZSBEa8ZVY9HspcGUYaK63d/bN7rqS3CYCzEGUxuYv6UlmcjzDUz2fCFFHyTvUW5Pk0I+3hkA3iXlIj6guA==",
+			"requires": {
+				"get-proxy": "^2.0.0",
+				"isurl": "^1.0.0-alpha5",
+				"tunnel-agent": "^0.6.0",
+				"url-to-options": "^1.0.1"
+			}
 		},
 		"chalk": {
 			"version": "2.4.2",
@@ -199,6 +344,14 @@
 				}
 			}
 		},
+		"clone-response": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+			"integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+			"requires": {
+				"mimic-response": "^1.0.0"
+			}
+		},
 		"color-convert": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -223,8 +376,36 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"config-chain": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
+			"integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
+			"requires": {
+				"ini": "^1.3.4",
+				"proto-list": "~1.2.1"
+			}
+		},
+		"content-disposition": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+			"integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+			"requires": {
+				"safe-buffer": "5.1.2"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+				}
+			}
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
 		"debug": {
 			"version": "3.2.6",
@@ -241,6 +422,126 @@
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 			"dev": true
 		},
+		"decode-uri-component": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+		},
+		"decompress": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
+			"integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
+			"requires": {
+				"decompress-tar": "^4.0.0",
+				"decompress-tarbz2": "^4.0.0",
+				"decompress-targz": "^4.0.0",
+				"decompress-unzip": "^4.0.1",
+				"graceful-fs": "^4.1.10",
+				"make-dir": "^1.0.0",
+				"pify": "^2.3.0",
+				"strip-dirs": "^2.0.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+				}
+			}
+		},
+		"decompress-response": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+			"requires": {
+				"mimic-response": "^1.0.0"
+			}
+		},
+		"decompress-tar": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
+			"integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
+			"requires": {
+				"file-type": "^5.2.0",
+				"is-stream": "^1.1.0",
+				"tar-stream": "^1.5.2"
+			},
+			"dependencies": {
+				"file-type": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
+					"integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY="
+				}
+			}
+		},
+		"decompress-tarbz2": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
+			"integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
+			"requires": {
+				"decompress-tar": "^4.1.0",
+				"file-type": "^6.1.0",
+				"is-stream": "^1.1.0",
+				"seek-bzip": "^1.0.5",
+				"unbzip2-stream": "^1.0.9"
+			},
+			"dependencies": {
+				"file-type": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
+					"integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg=="
+				}
+			}
+		},
+		"decompress-targz": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
+			"integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
+			"requires": {
+				"decompress-tar": "^4.1.1",
+				"file-type": "^5.2.0",
+				"is-stream": "^1.1.0"
+			},
+			"dependencies": {
+				"file-type": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
+					"integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY="
+				}
+			}
+		},
+		"decompress-unzip": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
+			"integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
+			"requires": {
+				"file-type": "^3.8.0",
+				"get-stream": "^2.2.0",
+				"pify": "^2.3.0",
+				"yauzl": "^2.4.2"
+			},
+			"dependencies": {
+				"file-type": {
+					"version": "3.9.0",
+					"resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+					"integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
+				},
+				"get-stream": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+					"integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
+					"requires": {
+						"object-assign": "^4.0.1",
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"pify": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+				}
+			}
+		},
 		"define-properties": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -256,11 +557,43 @@
 			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
 			"dev": true
 		},
+		"download": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/download/-/download-7.1.0.tgz",
+			"integrity": "sha512-xqnBTVd/E+GxJVrX5/eUJiLYjCGPwMpdL+jGhGU57BvtcA7wwhtHVbXBeUk51kOpW3S7Jn3BQbN9Q1R1Km2qDQ==",
+			"requires": {
+				"archive-type": "^4.0.0",
+				"caw": "^2.0.1",
+				"content-disposition": "^0.5.2",
+				"decompress": "^4.2.0",
+				"ext-name": "^5.0.0",
+				"file-type": "^8.1.0",
+				"filenamify": "^2.0.0",
+				"get-stream": "^3.0.0",
+				"got": "^8.3.1",
+				"make-dir": "^1.2.0",
+				"p-event": "^2.1.0",
+				"pify": "^3.0.0"
+			}
+		},
+		"duplexer3": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+		},
 		"emoji-regex": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
 			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
 			"dev": true
+		},
+		"end-of-stream": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+			"requires": {
+				"once": "^1.4.0"
+			}
 		},
 		"es-abstract": {
 			"version": "1.17.0",
@@ -310,8 +643,7 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"esprima": {
 			"version": "4.0.1",
@@ -324,6 +656,51 @@
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
+		},
+		"ext-list": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
+			"integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
+			"requires": {
+				"mime-db": "^1.28.0"
+			}
+		},
+		"ext-name": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
+			"integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
+			"requires": {
+				"ext-list": "^2.0.0",
+				"sort-keys-length": "^1.0.0"
+			}
+		},
+		"fd-slicer": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+			"integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+			"requires": {
+				"pend": "~1.2.0"
+			}
+		},
+		"file-type": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-8.1.0.tgz",
+			"integrity": "sha512-qyQ0pzAy78gVoJsmYeNgl8uH8yKhr1lVhW7JbzJmnlRi0I4R2eEDEJZVKG8agpDnLpacwNbDhLNG/LMdxHD2YQ=="
+		},
+		"filename-reserved-regex": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+			"integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik="
+		},
+		"filenamify": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/filenamify/-/filenamify-2.1.0.tgz",
+			"integrity": "sha512-ICw7NTT6RsDp2rnYKVd8Fu4cr6ITzGy3+u4vUujPkabyaz+03F24NWEX7fs5fp+kBonlaqPH8fAO2NM+SXt/JA==",
+			"requires": {
+				"filename-reserved-regex": "^2.0.0",
+				"strip-outer": "^1.0.0",
+				"trim-repeated": "^1.0.0"
+			}
 		},
 		"find-up": {
 			"version": "3.0.0",
@@ -343,11 +720,24 @@
 				"is-buffer": "~2.0.3"
 			}
 		},
+		"from2": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+			"requires": {
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.0"
+			}
+		},
+		"fs-constants": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"function-bind": {
 			"version": "1.1.1",
@@ -361,11 +751,23 @@
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
 			"dev": true
 		},
+		"get-proxy": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-2.1.0.tgz",
+			"integrity": "sha512-zmZIaQTWnNQb4R4fJUEp/FC51eZsc6EkErspy3xtIYStaq8EB/hDIWipxsal+E8rz0qD7f2sL/NA9Xee4RInJw==",
+			"requires": {
+				"npm-conf": "^1.1.0"
+			}
+		},
+		"get-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+		},
 		"glob": {
 			"version": "7.1.6",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
 			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -374,6 +776,40 @@
 				"once": "^1.3.0",
 				"path-is-absolute": "^1.0.0"
 			}
+		},
+		"got": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/got/-/got-8.3.2.tgz",
+			"integrity": "sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==",
+			"requires": {
+				"@sindresorhus/is": "^0.7.0",
+				"cacheable-request": "^2.1.1",
+				"decompress-response": "^3.3.0",
+				"duplexer3": "^0.1.4",
+				"get-stream": "^3.0.0",
+				"into-stream": "^3.1.0",
+				"is-retry-allowed": "^1.1.0",
+				"isurl": "^1.0.0-alpha5",
+				"lowercase-keys": "^1.0.0",
+				"mimic-response": "^1.0.0",
+				"p-cancelable": "^0.4.0",
+				"p-timeout": "^2.0.1",
+				"pify": "^3.0.0",
+				"safe-buffer": "^5.1.1",
+				"timed-out": "^4.0.1",
+				"url-parse-lax": "^3.0.0",
+				"url-to-options": "^1.0.1"
+			}
+		},
+		"graceful-fs": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+			"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
+		},
+		"graceful-readlink": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+			"integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
 		},
 		"growl": {
 			"version": "1.10.5",
@@ -396,17 +832,35 @@
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 			"dev": true
 		},
+		"has-symbol-support-x": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
+			"integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
+		},
 		"has-symbols": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
 			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
 			"dev": true
 		},
+		"has-to-string-tag-x": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+			"integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+			"requires": {
+				"has-symbol-support-x": "^1.4.1"
+			}
+		},
 		"he": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
 			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
 			"dev": true
+		},
+		"http-cache-semantics": {
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
+			"integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
 		},
 		"http-proxy-agent": {
 			"version": "2.1.0",
@@ -445,11 +899,15 @@
 				"debug": "^3.1.0"
 			}
 		},
+		"ieee754": {
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -458,8 +916,21 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+		},
+		"ini": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+		},
+		"into-stream": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+			"integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
+			"requires": {
+				"from2": "^2.1.1",
+				"p-is-promise": "^1.1.0"
+			}
 		},
 		"is-buffer": {
 			"version": "2.0.4",
@@ -485,6 +956,21 @@
 			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
 			"dev": true
 		},
+		"is-natural-number": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
+			"integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg="
+		},
+		"is-object": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+			"integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
+		},
+		"is-plain-obj": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+		},
 		"is-regex": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
@@ -493,6 +979,16 @@
 			"requires": {
 				"has": "^1.0.3"
 			}
+		},
+		"is-retry-allowed": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+			"integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
+		},
+		"is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
 		},
 		"is-symbol": {
 			"version": "1.0.3",
@@ -503,11 +999,25 @@
 				"has-symbols": "^1.0.1"
 			}
 		},
+		"isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
 			"dev": true
+		},
+		"isurl": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
+			"integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+			"requires": {
+				"has-to-string-tag-x": "^1.2.0",
+				"is-object": "^1.0.1"
+			}
 		},
 		"js-tokens": {
 			"version": "4.0.0",
@@ -523,6 +1033,19 @@
 			"requires": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
+			}
+		},
+		"json-buffer": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+			"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
+		},
+		"keyv": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
+			"integrity": "sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==",
+			"requires": {
+				"json-buffer": "3.0.0"
 			}
 		},
 		"locate-path": {
@@ -550,11 +1073,33 @@
 				"chalk": "^2.0.1"
 			}
 		},
+		"lowercase-keys": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+		},
+		"make-dir": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+			"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+			"requires": {
+				"pify": "^3.0.0"
+			}
+		},
+		"mime-db": {
+			"version": "1.43.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+			"integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+		},
+		"mimic-response": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -566,12 +1111,20 @@
 			"dev": true
 		},
 		"mkdirp": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
+			"integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
 			"dev": true,
 			"requires": {
-				"minimist": "0.0.8"
+				"minimist": "^1.2.5"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+					"dev": true
+				}
 			}
 		},
 		"mocha": {
@@ -618,6 +1171,15 @@
 						"once": "^1.3.0",
 						"path-is-absolute": "^1.0.0"
 					}
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+					"dev": true,
+					"requires": {
+						"minimist": "0.0.8"
+					}
 				}
 			}
 		},
@@ -636,6 +1198,40 @@
 				"object.getownpropertydescriptors": "^2.0.3",
 				"semver": "^5.7.0"
 			}
+		},
+		"normalize-url": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
+			"integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
+			"requires": {
+				"prepend-http": "^2.0.0",
+				"query-string": "^5.0.1",
+				"sort-keys": "^2.0.0"
+			},
+			"dependencies": {
+				"sort-keys": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+					"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+					"requires": {
+						"is-plain-obj": "^1.0.0"
+					}
+				}
+			}
+		},
+		"npm-conf": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/npm-conf/-/npm-conf-1.1.3.tgz",
+			"integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
+			"requires": {
+				"config-chain": "^1.1.11",
+				"pify": "^3.0.0"
+			}
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
 		"object-inspect": {
 			"version": "1.7.0",
@@ -675,10 +1271,32 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
+		},
+		"p-cancelable": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+			"integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ=="
+		},
+		"p-event": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/p-event/-/p-event-2.3.1.tgz",
+			"integrity": "sha512-NQCqOFhbpVTMX4qMe8PF8lbGtzZ+LCiN7pcNrb/413Na7+TRoe1xkKUzuWa/YEJdGQ0FvKtj35EEbDoVPO2kbA==",
+			"requires": {
+				"p-timeout": "^2.0.1"
+			}
+		},
+		"p-finally": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+		},
+		"p-is-promise": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+			"integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
 		},
 		"p-limit": {
 			"version": "2.2.2",
@@ -698,6 +1316,14 @@
 				"p-limit": "^2.0.0"
 			}
 		},
+		"p-timeout": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
+			"integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
+			"requires": {
+				"p-finally": "^1.0.0"
+			}
+		},
 		"p-try": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -713,14 +1339,82 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-parse": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
 			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
 			"dev": true
+		},
+		"pend": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+			"integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+		},
+		"pify": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+		},
+		"pinkie": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+		},
+		"pinkie-promise": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"requires": {
+				"pinkie": "^2.0.0"
+			}
+		},
+		"prepend-http": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+			"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
+		},
+		"process-nextick-args": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+		},
+		"proto-list": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+			"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
+		},
+		"query-string": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+			"integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+			"requires": {
+				"decode-uri-component": "^0.2.0",
+				"object-assign": "^4.1.0",
+				"strict-uri-encode": "^1.0.0"
+			}
+		},
+		"readable-stream": {
+			"version": "2.3.7",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+			"requires": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+				}
+			}
 		},
 		"require-directory": {
 			"version": "2.1.1",
@@ -743,13 +1437,43 @@
 				"path-parse": "^1.0.6"
 			}
 		},
+		"responselike": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+			"integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+			"requires": {
+				"lowercase-keys": "^1.0.0"
+			}
+		},
 		"rimraf": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-			"dev": true,
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
 			"requires": {
 				"glob": "^7.1.3"
+			}
+		},
+		"safe-buffer": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+			"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+		},
+		"seek-bzip": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
+			"integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
+			"requires": {
+				"commander": "~2.8.1"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.8.1",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+					"integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
+					"requires": {
+						"graceful-readlink": ">= 1.0.0"
+					}
+				}
 			}
 		},
 		"semver": {
@@ -764,11 +1488,41 @@
 			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 			"dev": true
 		},
+		"sha.js": {
+			"version": "2.4.11",
+			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+			"requires": {
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"sort-keys": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+			"integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+			"requires": {
+				"is-plain-obj": "^1.0.0"
+			}
+		},
+		"sort-keys-length": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/sort-keys-length/-/sort-keys-length-1.0.1.tgz",
+			"integrity": "sha1-nLb09OnkgVWmqgZx7dM2/xR5oYg=",
+			"requires": {
+				"sort-keys": "^1.0.0"
+			}
+		},
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
 			"dev": true
+		},
+		"strict-uri-encode": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
 		},
 		"string-width": {
 			"version": "2.1.1",
@@ -800,6 +1554,21 @@
 				"function-bind": "^1.1.1"
 			}
 		},
+		"string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"requires": {
+				"safe-buffer": "~5.1.0"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+				}
+			}
+		},
 		"strip-ansi": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -809,11 +1578,27 @@
 				"ansi-regex": "^3.0.0"
 			}
 		},
+		"strip-dirs": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
+			"integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
+			"requires": {
+				"is-natural-number": "^4.0.1"
+			}
+		},
 		"strip-json-comments": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
 			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 			"dev": true
+		},
+		"strip-outer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+			"integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+			"requires": {
+				"escape-string-regexp": "^1.0.2"
+			}
 		},
 		"supports-color": {
 			"version": "6.0.0",
@@ -822,6 +1607,43 @@
 			"dev": true,
 			"requires": {
 				"has-flag": "^3.0.0"
+			}
+		},
+		"tar-stream": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+			"integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+			"requires": {
+				"bl": "^1.0.0",
+				"buffer-alloc": "^1.2.0",
+				"end-of-stream": "^1.0.0",
+				"fs-constants": "^1.0.0",
+				"readable-stream": "^2.3.0",
+				"to-buffer": "^1.1.1",
+				"xtend": "^4.0.0"
+			}
+		},
+		"through": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+		},
+		"timed-out": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+		},
+		"to-buffer": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+			"integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
+		},
+		"trim-repeated": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+			"integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
+			"requires": {
+				"escape-string-regexp": "^1.0.2"
 			}
 		},
 		"tslib": {
@@ -868,11 +1690,46 @@
 				"tslib": "^1.8.1"
 			}
 		},
+		"tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"requires": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
 		"typescript": {
 			"version": "3.7.4",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.4.tgz",
 			"integrity": "sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==",
 			"dev": true
+		},
+		"unbzip2-stream": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
+			"integrity": "sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==",
+			"requires": {
+				"buffer": "^5.2.1",
+				"through": "^2.3.8"
+			}
+		},
+		"url-parse-lax": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+			"integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+			"requires": {
+				"prepend-http": "^2.0.0"
+			}
+		},
+		"url-to-options": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
+			"integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"vscode-cpptools": {
 			"version": "3.0.1",
@@ -894,6 +1751,17 @@
 				"http-proxy-agent": "^2.1.0",
 				"https-proxy-agent": "^2.2.4",
 				"rimraf": "^2.6.3"
+			},
+			"dependencies": {
+				"rimraf": {
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				}
 			}
 		},
 		"which": {
@@ -962,8 +1830,12 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		},
+		"xtend": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
 		},
 		"y18n": {
 			"version": "4.0.0",
@@ -1036,6 +1908,15 @@
 				"flat": "^4.1.0",
 				"lodash": "^4.17.15",
 				"yargs": "^13.3.0"
+			}
+		},
+		"yauzl": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+			"integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+			"requires": {
+				"buffer-crc32": "~0.2.3",
+				"fd-slicer": "~1.1.0"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -68,6 +68,11 @@
 				"command": "qttools.currentfileincreator",
 				"title": "Edit in Qt Creator",
 				"category": "Qt"
+			},
+			{
+				"command": "qttools.removenatviscache",
+				"title": "Delete natvis download cache",
+				"category": "Qt"
 			}
 		],
 		"menus": {
@@ -178,6 +183,9 @@
 		"@types/mocha": "^5.2.7",
 		"@types/node": "^12.11.7",
 		"@types/vscode": "^1.41.0",
+		"@types/download": "^6.2.4",
+		"@types/sha.js": "^2.4.0",
+		"@types/rimraf": "^2.0.3",
 		"glob": "^7.1.5",
 		"mocha": "^6.2.2",
 		"typescript": "^3.6.4",
@@ -186,6 +194,9 @@
 		"vscode-cpptools": "^3.0.1"
 	},
 	"dependencies": {
+		"download": "^7.1.0",
+		"rimraf": "^3.0.2",
+		"sha.js": "^2.4.11",
 		"vscode-jsonrpc": "^4.0.0"
 	},
 	"icon": "icon.png",

--- a/src/downloader.ts
+++ b/src/downloader.ts
@@ -1,0 +1,79 @@
+import * as vscode from 'vscode';
+import * as download from 'download';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as shajs from 'sha.js';
+import * as rimraf from 'rimraf';
+
+interface IDownloadState {
+    (text: string): void;
+}
+
+export class NatvisDownloader implements vscode.Disposable {
+    private _context: vscode.ExtensionContext;
+    public downloadStateCallback: IDownloadState | null = null;
+
+    constructor(public readonly extensionContext: vscode.ExtensionContext) {
+        this._context = extensionContext;
+    }
+
+    get natvisFolder(): string {
+        return path.join(this._context.globalStoragePath, "natvis");
+    }
+
+    public clearDownloadCache() {
+        if (fs.existsSync(this.natvisFolder)) {
+            rimraf.sync(this.natvisFolder);
+        }
+    }
+
+    private async getCacheFilename(url: string): Promise<string> {
+        const url_hash = shajs("sha256").update(url).digest("hex");
+        const cache_file = path.join(this.natvisFolder, url_hash);
+        return cache_file;
+    }
+
+    public async inCache(url: string): Promise<boolean> {
+        const cache_file = await this.getCacheFilename(url);
+        return fs.existsSync(cache_file);
+    }
+
+    private reportDownloadState(text: string) {
+        if (this.downloadStateCallback) {
+            this.downloadStateCallback(text);
+        }
+    }
+
+    /**
+     * Download the given natvis url. The files get cached, so when the url 
+     * is already download this function will return the cache_file name instantly.
+     * @param url to the natvis file which should be downloaded
+     * @returns absolute path to the local downloaded file
+     */
+    public async download(url: string): Promise<string> {
+        if (!fs.existsSync(this.natvisFolder)) {
+            fs.mkdirSync(this.natvisFolder, { recursive: true });
+        }
+        const cache_file = await this.getCacheFilename(url);
+        if (fs.existsSync(cache_file)) {
+            return cache_file;
+        }
+        this.reportDownloadState(`downlad natvis file from ${url}`);
+        const data = await download(url);
+        this.reportDownloadState("download succeeded");
+        const text = data.toString();
+        if (text.indexOf("QString") >= 0) {
+            fs.writeFileSync(cache_file, data);
+            if (fs.existsSync(cache_file)) {
+                return cache_file;
+            }
+        } else {
+            this.reportDownloadState("download file seems no to be a Qt natvis file");
+        }
+        return "";
+    }
+
+    dispose() {
+
+    }
+}


### PR DESCRIPTION
This PR will add url support for `qttools.visualizerFile`, f.e you can now set the value `https://code.qt.io/cgit/qt-labs/vstools.git/plain/src/qtvstools/qt5.natvis.xml`.