### PR TITLE
Add PATH search fallback

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -51,6 +51,11 @@ class ExtensionManager implements vscode.Disposable {
 			if (Qt5_DIR) {
 				this.logger.debug(`search Qt root directory in Qt5_DIR "${Qt5_DIR}"`);
 				qtRootDir = qt.findQtRootDirViaCmakeDir(Qt5_DIR);
+				if (!qtRootDir) {
+					this.logger.debug(`could not find executables in ${Qt5_DIR}, fallback to PATH search`);
+					// search in PATH
+					qtRootDir = qt.findQtRootDirViaPathEnv();
+				}
 				this.logger.debug(`Qt root directory is "${qtRootDir}"`);
 			}
 			else {

--- a/src/qt.ts
+++ b/src/qt.ts
@@ -22,6 +22,25 @@ function searchFileInDirectories(directories: Array<string>, filenames: Array<st
     return "";
 }
 
+export function findQtRootDirViaPathEnv(): string {
+    let result = "";
+    if ("PATH" in process.env) {
+        const PATH = process.env.PATH || "";
+        let splitter = ":";
+        if (process.platform === "win32") {
+            splitter = ";";
+        }
+        const paths = PATH.split(splitter);
+        const exeExtension = tools.exeExtension();
+        const mocFilenameOnly = `qmake${exeExtension}`;
+        const mocPath = searchFileInDirectories(paths, [mocFilenameOnly]);
+        if (mocPath) {
+            result = path.dirname(mocPath);
+        }
+    }
+    return result;
+}
+
 export function findQtRootDirViaCmakeDir(qt5_dir: string): string {
     let result = "";
     if (fs.existsSync(qt5_dir)) {
@@ -33,7 +52,7 @@ export function findQtRootDirViaCmakeDir(qt5_dir: string): string {
             const mocFilenameOnly = `qmake${exeExtension}`;
             const tmpPath = path.join(tmpBasePath, "bin", mocFilenameOnly);
             if (fs.existsSync(tmpPath)) {
-                return tmpBasePath;
+                return path.dirname(tmpPath);
             }
             else {
                 splits.pop();
@@ -70,7 +89,7 @@ export class Qt {
         let searchdirs = [];
         let filesnames = ["designer" + tools.exeExtension(), "Designer" + tools.exeExtension()];
         if (this.basedir) {
-            searchdirs.push(path.join(this.basedir, "bin"));
+            searchdirs.push(this.basedir);
             if (process.platform === "darwin") {
                 filesnames.push(path.join("Designer.app", "Contents", "MacOS", "Designer"));
             }
@@ -103,7 +122,7 @@ export class Qt {
         let searchdirs = [];
         let filesnames = ["assistant" + tools.exeExtension(), "Assistant" + tools.exeExtension()];
         if (this.basedir) {
-            searchdirs.push(path.join(this.basedir, "bin"));
+            searchdirs.push(this.basedir);
             if (process.platform === "darwin") {
                 filesnames.push(path.join("Assistant.app", "Contents", "MacOS", "Assistant"));
             }


### PR DESCRIPTION
This PR will look for qt bin files in the directories provided by the `CMakeCache.txt` file as before. If it could not find the `qmake` executable (that is the case when it is a system wide installation of Qt, because there is no direct parent directory for `bin` and `lib`) in one of the parent directories it will look into the directories provided by the  `PATH` environment variable for `qmake`.

Closes #26 