### PR TITLE
Use command uri instead of active document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.6
+- Add logger
+- Open a current file via context menu will now use the underlying document instead of the active one
+
 ## 0.5
 - add support for ${buildKit} and ${buildType} in `cmake.buildDirectory`
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -405,10 +405,10 @@ export async function activate(context: vscode.ExtensionContext) {
 		}
 	});
 
-	_EXT_MANAGER.registerCommand('qttools.currentfileindesigner', async () => {
+	_EXT_MANAGER.registerCommand('qttools.currentfileindesigner', async (uri: vscode.Uri) => {
 		if (_EXT_MANAGER && _EXT_MANAGER.qtManager) {
 			await _EXT_MANAGER.updateState();
-			const current_file = _EXT_MANAGER.getActiveDocumentFilename();
+			const current_file = uri.fsPath;
 			if (current_file) {
 				try {
 					_EXT_MANAGER.qtManager.launchDesigner(current_file);
@@ -465,10 +465,10 @@ export async function activate(context: vscode.ExtensionContext) {
 		}
 	});
 
-	_EXT_MANAGER.registerCommand('qttools.currentfileincreator', async () => {
+	_EXT_MANAGER.registerCommand('qttools.currentfileincreator', async (uri: vscode.Uri) => {
 		if (_EXT_MANAGER && _EXT_MANAGER.qtManager) {
 			await _EXT_MANAGER.updateState();
-			const current_file = _EXT_MANAGER.getActiveDocumentFilename();
+			const current_file = uri.fsPath;
 			if (current_file) {
 				try {
 					_EXT_MANAGER.qtManager.launchCreator(current_file);


### PR DESCRIPTION
Use the uri given by the command instead of the active document.

Closes #29 