### PR TITLE
Get cmake.buildDirectory directly from cmake tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Change Log
 
 ## 0.6
+Big shout out to [@Shatur95](https://github.com/Shatur95) for his support 🙏
 - Add logger
 - Open a current file via context menu will now use the underlying document instead of the active one
+- Get cmake.buildDirectory directly from cmake tools extension
 
 ## 0.5
 - add support for ${buildKit} and ${buildType} in `cmake.buildDirectory`

--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ At the moment the extension extracts the Qt file locations from CMake only (from
 * There are some situation where the automatic detection mechanism of Qt is not working. If that is the case you can always trigger the `Scan for Qt kits` command in the command palette.
 * The debugger extension use normal natvis xml files (used via the `launch.json` setting `visualizerFile` from the [C/C++ extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) ). They work really well on windows, but on mac and linux there are some problems, because it is not based on the same implementation. If you have any problems with them create an issue on their issue tracker.
 
+## Variable substitution
+The `cmake.buildDirectory` from `cmake tools` support variable substitution which looks like `${myvariable}` (example `${generator}`).
+
+This extension supports every variable substitution from `cmake tools` when the `cmake tools` extension is installed and active.
+
+If `cmake tools` is not active the extension will fallback to the content of the `cmake.buildDirectory`. In this mode only `${buildType}`, `${buildKit}` and `${workspaceFolder}` are supported variable substitutions!
+
+## Troubleshooting
+If you have problems with the extension just file a issue on [GitHub](https://github.com/tonka3000/vscode-qt-tools/issues). It's mostly a good idea to attach the log output of this extension to the issue. You can active the logger by adding `"qttools.loglevel": "debug"` to your `settings.json` file. Just copy the content of the `Qt` output pane into your GitHub issue.
+
 ## Contributions
 Pull requests are welcome :-D
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -420,6 +420,7 @@ export async function activate(context: vscode.ExtensionContext) {
 					activeCounter++;
 					logger.debug(`wait for cmake tools to get active (${activeCounter})`);
 					if (activeCounter > 15) { // ~15 seconds timeout
+						logger.debug("cmake tools is not active, timed out");
 						return resolve(); // waiting for cmake tools timed out
 					}
 					setTimeout(isActive, 1000);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,6 +25,7 @@ class ExtensionManager implements vscode.Disposable {
 		this.qtManager = new qt.Qt(this._channel, this._context.extensionPath);
 		this.cmakeCache = new cmake.CMakeCache();
 		this.natvisDownloader = new NatvisDownloader(this._context);
+		this.logger.level = this.getLogLevel();
 
 		this.natvisDownloader.downloadStateCallback = (text: string) => {
 			this._channel.appendLine(text);
@@ -43,6 +44,7 @@ class ExtensionManager implements vscode.Disposable {
 		this.logger.level = this.getLogLevel();
 		this.logger.debug("update state");
 		if (this.cmakeCache) {
+			this.logger.debug(`cmake build directory: ${await this.getCMakeBuildDirectory()}`);
 			this.cmakeCache.filename = await this.getCmakeCacheFilename();
 			this.logger.debug(`read cmake cache from ${this.cmakeCache.filename}`);
 			await this.cmakeCache.readCache();
@@ -189,9 +191,13 @@ class ExtensionManager implements vscode.Disposable {
 	}
 
 	public async getCMakeBuildDirectory(): Promise<string> {
-		const workbenchConfig = vscode.workspace.getConfiguration();
-		let cmakeBuildDir = String(workbenchConfig.get('cmake.buildDirectory'));
-		cmakeBuildDir = await this.resolveSubstitutionVariables(cmakeBuildDir);
+		let cmakeBuildDir = await this.getActiveCMakeBuildDirectory();
+		if (!cmakeBuildDir) {
+			// fallback to config file when we can not get the info from cmake tools extension directly
+			const workbenchConfig = vscode.workspace.getConfiguration();
+			cmakeBuildDir = String(workbenchConfig.get('cmake.buildDirectory'));
+			cmakeBuildDir = await this.resolveSubstitutionVariables(cmakeBuildDir);
+		}
 		return cmakeBuildDir;
 	}
 
@@ -222,6 +228,20 @@ class ExtensionManager implements vscode.Disposable {
 		}
 		catch (error) {
 
+		}
+		return result;
+	}
+
+	public async getActiveCMakeBuildDirectory(): Promise<string> {
+		let result = "";
+		const command = "cmake.buildDirectory";
+		if ((await vscode.commands.getCommands()).includes(command)) {
+			try {
+				result = await vscode.commands.executeCommand(command) || "";
+			}
+			catch (error) {
+
+			}
 		}
 		return result;
 	}
@@ -383,13 +403,36 @@ class ExtensionManager implements vscode.Disposable {
 let _EXT_MANAGER: ExtensionManager | null = null;
 
 export async function activate(context: vscode.ExtensionContext) {
+	_EXT_MANAGER = new ExtensionManager(context);
+	const logger = _EXT_MANAGER.logger;
 
-	const oldCMakeToolsExtension = vscode.extensions.getExtension('ms-vscode.cmake-tools');
-	if (!oldCMakeToolsExtension) {
-		await vscode.window.showWarningMessage('could not find cmake tools');
+	const cmakeTools = vscode.extensions.getExtension('ms-vscode.cmake-tools');
+	if (cmakeTools) {
+		if (!cmakeTools.isActive) {
+			logger.debug("cmake tools extension is not active, waiting for it");
+			let activeCounter = 0;
+			await new Promise((resolve) => {
+				const isActive = () => {
+					if (cmakeTools && cmakeTools.isActive) {
+						logger.debug("cmake tools is active");
+						return resolve();
+					}
+					activeCounter++;
+					logger.debug(`wait for cmake tools to get active (${activeCounter})`);
+					if (activeCounter > 15) { // ~15 seconds timeout
+						return resolve(); // waiting for cmake tools timed out
+					}
+					setTimeout(isActive, 1000);
+				};
+				isActive();
+			});
+
+		}
+	}
+	else {
+		await vscode.window.showWarningMessage('cmake tools extension is not installed or enabled');
 	}
 
-	_EXT_MANAGER = new ExtensionManager(context);
 	_EXT_MANAGER.updateState();
 
 	_EXT_MANAGER.registerCommand('qttools.launchdesigneronly', async () => {


### PR DESCRIPTION
Get `cmake.buildDirectory` from `cmake tools` directly via command. If the `cmake tools` extension is not present, we will fallback to the content of the `cmake.buildDirectory` in the `settings.json` file as before.

Closes #28

Big shout out to @Shatur95 🙏 