### PR TITLE
Add Qt search mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.9.0
+
+- Add optinoal PATH mode
+- Add support for Qt6<br>
+  Thanks for the help [@Animeshdhakal](https://github.com/Animeshdhakal) and [@macdew](https://github.com/macdew) 🙏
+
 ## 0.8.3
 
 - Bump lodash from 4.17.19 to 4.17.21 to fix a security vulnerability

--- a/README.md
+++ b/README.md
@@ -2,35 +2,56 @@
 
 > This extension is work in progress, so some command/settings can change over time.
 
-> <span style="color:red; font-weight:bold;">This is NOT an offical tool by The Qt Company!!</span>
+> <span style="color:red; font-weight:bold;">This is NOT an official tool by The Qt Company!!</span>
 
-This is a Qt extension for VSCode. It is designed to be a similar tool to the [Qt Visual Studio Tools](https://marketplace.visualstudio.com/items?itemName=TheQtCompany.QtVisualStudioTools-19123) from The Qt Company, but it tries to cooperate with other extensions for some functionality like f.e. debugging.
+This is a Qt extension for VSCode. It is designed to be a similar tool to the [Qt Visual Studio Tools](https://marketplace.visualstudio.com/items?itemName=TheQtCompany.QtVisualStudioTools-19123) from The Qt Company, but it tries to cooperate with other extensions for some functionality like e.g. debugging.
 
-At the moment the extension extracts the Qt file locations from CMake only (from [CMake Tools extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools) setting `cmake.buildDirectory`), so choosing and different Qt version from disk is not supported at the moment (but if you use cmake already, everything is automatically detected :-) ).
+The extension supports Qt file location extractions via
+* CMake
+* `PATH` environment variable
+
+Choosing a different Qt version from disk via this extension is not supported!
 
 ## Features
 
 * [x] Launch Qt Designer
 * [x] Edit `.ui` file in Qt Designer
 * [x] Launch Qt Assistant
-* [x] Launch Qt online documenation
+* [x] Launch Qt online documentation
 * [x] Launch Visual Studio (Windows only)
 * [x] Launch Qt Creator<br>
   `.ui` and `.qrc` files can be opened in Qt Creator. You can also open the whole workspace in Qt Creator too.<br>
   This extension try to detect the Qt Creator installation automatically (on Windows and MacOS). You can set the executable path via `qttools.creator` settings if the extension can't find Qt Creator (for whatever reason)
-* [x] Extract the Qt file locations from the cmake cache (`CMakeCache.txt`). The cmake build directory is extracted from the vscode extension [CMake Tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools) setting `cmake.buildDirectory`. 
-  So you need to configure your project for the first time and afterwards every Qt tool is found automatically (when it is installed on your disk ;-) ).
+* [x] Extract the Qt file locations from the cmake cache
+* [x] Extract the Qt file locations via `PATH` environment variable
 * [x] Debugger extensions (via natvis files)<br>
   The Qt natvis file from this extension will automatically get injected into your existing `launch.json` file (per default). If you don't like that feature you can turn it of via `qttools.injectNatvisFile` setting.<br>
   You can also set your custom created/downloaded qt natvis file instead of the bundled one (which implement a few Qt types) by setting `qttools.visualizerFile` to a filepath or url (f.e. you can set `qttools.visualizerFile` to the natvis file from the offical [Qt Visual Studio Tools](https://code.qt.io/cgit/qt-labs/vstools.git/tree/src/qtvstools/qt5.natvis.xml) `https://code.qt.io/cgit/qt-labs/vstools.git/plain/src/qtvstools/qt5.natvis.xml`). When you set an url, the extension will only download it ones and cache it and will use the cached local version<br>
   NOTE: I cannot bundle the Qt Visual Studio Tools natvis file into the extension itself because of it's license restrictions (MIT vs GPL)!
-* [ ] qml language support (there are already some VSCode extensions)
 * ...
 
 ## Requirements
 
-* You need to have the [CMake Tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools) installed, because this extension extracts some data from it!
+* You need to have the [CMake Tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools) installed if you have activated the `cmake` mode, because this extension extracts some data from it!
 * [C/C++ extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) is highly recommended
+
+## Qt search mode
+The search mode defines how this extension search the Qt binaries like qmake, Qt designer and so on.
+
+### CMake (default mode)
+`"qttools.searchMode": "cmake"`
+
+Extract the Qt file locations from the cmake cache (`CMakeCache.txt`). The cmake build directory is extracted from the VSCode extension [CMake Tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools) setting `cmake.buildDirectory`.
+You need to configure your project for the first time and afterwards every Qt tool is found automatically (when it is installed on your disk ;-) ) otherwise the launch of commands like `Launch Qt Designer` will fail.
+
+The benefit of this mode is that VSCode see the same Qt version as cmake is using, so it is automatically configured for you.
+
+### PATH
+`"qttools.searchMode": "path"`
+
+Search Qt in the `PATH` environment variable like it is done in the terminal. This mode helpful when you have a system wide Qt installation like on Linux based operating systems.
+
+You don't need to configure anything to be able to use the commands of this extension.
 
 ## Limitations
 
@@ -52,9 +73,9 @@ The Qt online help can be used with this extension. Right now only the latest Qt
 You  have 2 commands:
 
 * Qt: Online help  
-  This will open the Qt documentation. When you are in a `.cpp` or `.h` file and your cursor is inside a text block then the command will search that word as a class in the documenation.
+  This will open the Qt documentation. When you are in a `.cpp` or `.h` file and your cursor is inside a text block then the command will search that word as a class in the documentation.
 * Qt: Search online help  
-  This command will create a textbox inside vscode where you can enter your search term. This search term will be send to the search of the Qt Documenation.
+  This command will create a textbox inside vscode where you can enter your search term. This search term will be send to the search of the Qt Documentation.
 
 By default the qt website will be opened inside VSCode itself.
 
@@ -66,7 +87,7 @@ The integrate webview has some limitations:
   You can click the middle mouse button on that link and it will open in your external browser.
 * No navigation buttons
 
-You can also turn of the embedded webview for the online help and use your external browser by setting the `qttools.useExternalBrowser` to `true`. Be aware that you will get a popup from VSCode which informs you about opening an external website. To avoid getting this popup every time just press on `Configure Trsuted Domains` and choose `trust qt.io and all its subdomains`.
+You can also turn of the embedded webview for the online help and use your external browser by setting the `qttools.useExternalBrowser` to `true`. Be aware that you will get a popup from VSCode which informs you about opening an external website. To avoid getting this popup every time just press on `Configure Trusted Domains` and choose `trust qt.io and all its subdomains`.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Choosing a different Qt version from disk via this extension is not supported!
 
 ## Features
 
+* [x] Support for Qt 5 and Qt 6
 * [x] Launch Qt Designer
 * [x] Edit `.ui` file in Qt Designer
 * [x] Launch Qt Assistant

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "qtvsctools",
-	"version": "0.8.3",
+	"version": "0.9.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -174,15 +174,18 @@
 						"default": "",
 						"description": "filepath or url to a natvis.xml file which will be used instead of the bundled one. You can use f.e. `https://code.qt.io/cgit/qt-labs/vstools.git/plain/src/qtvstools/qt5.natvis.xml` when you want to use the file from Qt Visual Studio tools"
 					},
-					"qttools.searchMode" : {
+					"qttools.searchMode": {
 						"type": "string",
 						"default": "cmake",
-						"enum": ["cmake", "path"],
+						"enum": [
+							"cmake",
+							"path"
+						],
 						"description": "Qt search mode",
 						"enumDescriptions": [
 							"Search Qt based on cmake. The cmake project needs to be configured before Qt can be found",
 							"Search Qt in the PATH variable"
-						  ]
+						]
 					},
 					"qttools.creator": {
 						"type": "string",

--- a/package.json
+++ b/package.json
@@ -174,6 +174,16 @@
 						"default": "",
 						"description": "filepath or url to a natvis.xml file which will be used instead of the bundled one. You can use f.e. `https://code.qt.io/cgit/qt-labs/vstools.git/plain/src/qtvstools/qt5.natvis.xml` when you want to use the file from Qt Visual Studio tools"
 					},
+					"qttools.searchMode" : {
+						"type": "string",
+						"default": "cmake",
+						"enum": ["cmake", "path"],
+						"description": "Qt search mode",
+						"enumDescriptions": [
+							"Search Qt based on cmake. The cmake project needs to be configured before Qt can be found",
+							"Search Qt in the PATH variable"
+						  ]
+					},
 					"qttools.creator": {
 						"type": "string",
 						"default": "",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "qtvsctools",
 	"displayName": "Qt tools",
 	"description": "Qt tools support for VSCode",
-	"version": "0.8.3",
+	"version": "0.9.0",
 	"publisher": "tonka3000",
 	"preview": true,
 	"license": "MIT",

--- a/src/cmake.ts
+++ b/src/cmake.ts
@@ -52,7 +52,7 @@ export class CMakeCache {
                         const varName = groups[1];
                         const varType = groups[2];
                         const varValue = groups[3];
-                        if (varName.startsWith("Qt5") || varName.startsWith("CMAKE_PROJECT_NAME")) {
+                        if (varName.startsWith("Qt5") || varName.startsWith("Qt6") || varName.startsWith("CMAKE_PROJECT_NAME")) {
                             this.values[varName] = varValue;
                         }
                     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -51,37 +51,52 @@ class ExtensionManager implements vscode.Disposable {
 		if (this.help) {
 			this.help.useExternalBrowser = this.getUseExternalBrowserForOnlineHelp();
 		}
-		if (this.cmakeCache) {
-			this.logger.debug(`cmake build directory: ${await this.getCMakeBuildDirectory()}`);
-			this.cmakeCache.filename = await this.getCmakeCacheFilename();
-			this.logger.debug(`read cmake cache from ${this.cmakeCache.filename}`);
-			await this.cmakeCache.readCache();
-			const Qt5_DIR = this.cmakeCache.getKeyOrDefault("Qt5_DIR", this.cmakeCache.getKeyOrDefault("Qt5Core_DIR", ""));
-			let qtRootDir = "";
-			if (Qt5_DIR) {
-				this.logger.debug(`search Qt root directory in Qt5_DIR "${Qt5_DIR}"`);
-				qtRootDir = await qt.findQtRootDirViaCmakeDir(Qt5_DIR);
-				if (!qtRootDir) {
-					this.logger.debug(`could not find executables in ${Qt5_DIR}, fallback to PATH search`);
-					// search in PATH
-					qtRootDir = await qt.findQtRootDirViaPathEnv();
+		const qtSearchMode = await this.getQtSearchMode();
+		this.logger.debug(`Qt search mode '${qtSearchMode}'`);
+		if (qtSearchMode == "cmake") {
+			if (this.cmakeCache) {
+				this.logger.debug(`cmake build directory: ${await this.getCMakeBuildDirectory()}`);
+				this.cmakeCache.filename = await this.getCmakeCacheFilename();
+				this.logger.debug(`read cmake cache from ${this.cmakeCache.filename}`);
+				await this.cmakeCache.readCache();
+				const Qt5_DIR = this.cmakeCache.getKeyOrDefault("Qt5_DIR", this.cmakeCache.getKeyOrDefault("Qt5Core_DIR", ""));
+				let qtRootDir = "";
+				if (Qt5_DIR) {
+					this.logger.debug(`search Qt root directory in Qt5_DIR "${Qt5_DIR}"`);
+					qtRootDir = await qt.findQtRootDirViaCmakeDir(Qt5_DIR);
+					if (!qtRootDir) {
+						this.logger.debug(`could not find executables in ${Qt5_DIR}, fallback to PATH search`);
+						// search in PATH
+						qtRootDir = await qt.findQtRootDirViaPathEnv();
+					}
+					this.logger.debug(`Qt root directory is "${qtRootDir}"`);
 				}
-				this.logger.debug(`Qt root directory is "${qtRootDir}"`);
+				else {
+					this.logger.warning(`Could not find Qt5_DIR or Qt5Core_DIR in ${this.cmakeCache.filename}`);
+				}
+				const extraSearchDirs = this.getExtraSearchDirectories();
+				if (this.qtManager) {
+					this.logger.debug(`extra search directories: ${extraSearchDirs}`);
+					this.qtManager.extraSearchDirectories = extraSearchDirs;
+				}
+				this.setActiveKit(qtRootDir);
+				this.setupCMakeCacheWatcher();
+				if (qtRootDir) {
+					await this.generateNativsFile();
+					await this.injectNatvisFile();
+				}
 			}
-			else {
-				this.logger.warning(`Could not find Qt5_DIR or Qt5Core_DIR in ${this.cmakeCache.filename}`);
-			}
-			const extraSearchDirs = this.getExtraSearchDirectories();
-			if (this.qtManager) {
-				this.logger.debug(`extra search directories: ${extraSearchDirs}`);
-				this.qtManager.extraSearchDirectories = extraSearchDirs;
-			}
+		} else if (qtSearchMode == "path") {
+			this.logger.debug("search Qt root directory in PATH");
+			const qtRootDir = await qt.findQtRootDirViaPathEnv();
+			this.logger.debug(`Qt root directory from PATH '${qtRootDir}'`);
 			this.setActiveKit(qtRootDir);
-			this.setupCMakeCacheWatcher();
 			if (qtRootDir) {
 				await this.generateNativsFile();
 				await this.injectNatvisFile();
 			}
+		} else {
+			this.logger.error(`unknown Qt find mode '${qtSearchMode}'`);
 		}
 		if (this.qtManager) {
 			this.qtManager.setCreatorFilename(this.getCreatorFilenameSetting());
@@ -307,6 +322,19 @@ class ExtensionManager implements vscode.Disposable {
 		return visualizerFile;
 	}
 
+	public async getQtSearchMode(): Promise<string> {
+		const workbenchConfig = vscode.workspace.getConfiguration();
+		let result = workbenchConfig.get('qttools.searchMode') as string;
+		if (result) {
+			if (result !== "cmake" && result !== "path") {
+				result = "cmake";
+			}
+		} else {
+			result = "cmake";
+		}
+		return result;
+	}
+
 	public async generateNativsFile() {
 		this.logger.debug("generate natvis file");
 		const natvisTempalteFilename = await this.getNatvisTemplateFilepath();
@@ -427,32 +455,34 @@ export async function activate(context: vscode.ExtensionContext) {
 	_EXT_MANAGER = new ExtensionManager(context);
 	const logger = _EXT_MANAGER.logger;
 
-	const cmakeTools = vscode.extensions.getExtension('ms-vscode.cmake-tools');
-	if (cmakeTools) {
-		if (!cmakeTools.isActive) {
-			logger.debug("cmake tools extension is not active, waiting for it");
-			let activeCounter = 0;
-			await new Promise((resolve) => {
-				const isActive = () => {
-					if (cmakeTools && cmakeTools.isActive) {
-						logger.debug("cmake tools is active");
-						return resolve();
-					}
-					activeCounter++;
-					logger.debug(`wait for cmake tools to get active (${activeCounter})`);
-					if (activeCounter > 15) { // ~15 seconds timeout
-						logger.debug("cmake tools is not active, timed out");
-						return resolve(); // waiting for cmake tools timed out
-					}
-					setTimeout(isActive, 1000);
-				};
-				isActive();
-			});
+	if (await _EXT_MANAGER.getQtSearchMode() == "cmake") {
+		const cmakeTools = vscode.extensions.getExtension('ms-vscode.cmake-tools');
+		if (cmakeTools) {
+			if (!cmakeTools.isActive) {
+				logger.debug("cmake tools extension is not active, waiting for it");
+				let activeCounter = 0;
+				await new Promise((resolve) => {
+					const isActive = () => {
+						if (cmakeTools && cmakeTools.isActive) {
+							logger.debug("cmake tools is active");
+							return resolve();
+						}
+						activeCounter++;
+						logger.debug(`wait for cmake tools to get active (${activeCounter})`);
+						if (activeCounter > 15) { // ~15 seconds timeout
+							logger.debug("cmake tools is not active, timed out");
+							return resolve(); // waiting for cmake tools timed out
+						}
+						setTimeout(isActive, 1000);
+					};
+					isActive();
+				});
 
+			}
 		}
-	}
-	else {
-		await vscode.window.showWarningMessage('cmake tools extension is not installed or enabled');
+		else {
+			await vscode.window.showWarningMessage('cmake tools extension is not installed or enabled');
+		}
 	}
 
 	_EXT_MANAGER.updateState();

--- a/src/qt.ts
+++ b/src/qt.ts
@@ -5,6 +5,18 @@ import { platform } from "os";
 import * as vscode from 'vscode';
 import { spawn, execSync } from 'child_process';
 import * as os from "os";
+import * as cmake from './cmake';
+
+export function getQtDirFromCMakeCache(cache: cmake.CMakeCache) {
+    let result = "";
+    for (const qtKey of ["Qt5_DIR", "Qt5Core_DIR", "Qt6_DIR", "Qt6Core_DIR"]) {
+        result = cache.getKeyOrDefault(qtKey, "");
+        if (!!result) {
+            break;
+        }
+    }
+    return result;
+}
 
 async function searchFileInDirectories(directories: Array<string>, filenames: Array<string>): Promise<string> {
     for (let i = 0; i < directories.length; i++) {


### PR DESCRIPTION
Add Qt search mode. The default is `cmake`, but there is also a `path` mode.

Closes #38 
Closes #51 