### PR TITLE
Disable virtual workspace support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add multi-file support for Qt Creator
 - Upgrade typescript and webpack
+- Disable virtual workspaces support according to https://github.com/microsoft/vscode/wiki/Virtual-Workspaces
 
 ## 0.9.0
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,12 @@
 		"c++",
 		"native"
 	],
+	"capabilities": {
+		"virtualWorkspaces": {
+			"supported": false,
+			"description": "Qt tools doesn't support remote repositories."
+		}
+	},
 	"author": {
 		"name": "tonka3100"
 	},


### PR DESCRIPTION
Disable virtual workspace support according to https://github.com/microsoft/vscode/wiki/Virtual-Workspaces

The extension is based on local installed tools.