### PR TITLE
Add marked word support for the online help

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -550,6 +550,16 @@ export async function activate(context: vscode.ExtensionContext) {
 				if (editor) {
 					if (editor.document.fileName.endsWith(".cpp") || editor.document.fileName.endsWith(".h")) {
 						if (editor.selection.isEmpty) {
+							const range = editor.document.getWordRangeAtPosition(editor.selection.active, /\S+/);
+							if (range) {
+								word = editor.document.getText(range);
+								_EXT_MANAGER.logger.debug(`word under cursor: ${word}`);
+							}
+							else {
+								_EXT_MANAGER.logger.debug("no word under cursor");
+							}
+						}
+						else {
 							const wordrange = editor.document.getWordRangeAtPosition(editor.selection.active);
 							if (wordrange) {
 								word = editor.document.getText(wordrange);


### PR DESCRIPTION
Add support for the marked word under the cursor. 2 modes are built-in.

* selection

  Just use the word from the active selection

* Use the word, when the cursor is inside a word

related #62 